### PR TITLE
update rpm script for centos8

### DIFF
--- a/pkg/rpm/generate_rpms.sh
+++ b/pkg/rpm/generate_rpms.sh
@@ -6,6 +6,9 @@ version=$(grep KEYDB_REAL_VERSION $DIR/../../src/version.h | awk '{ printf $3 }'
 release=1 # by default this will always be 1 for keydb version structure. If build release version needs to be update you can modify here
 arch=$(uname -m)
 dist=el$(rpm -q --queryformat '%{VERSION}' centos-release | cut -d. -f1)
+if [[ "$dist" == "elpackage centos-release is not installed" ]]; then
+        dist=el$(rpm -q --queryformat '%{VERSION}' centos-linux-release  | cut -d. -f1)
+fi
 
 if [[ "$arch" != "aarch64" ]] && [[ "$arch" != "x86_64" ]]; then
 	echo "This script is only valid and tested for aarch64 and x86_64 architectures. You are trying to use: $arch"


### PR DESCRIPTION
Minor update to script. Building with new centos8 uses centos-linux-release