### PR TITLE
Fixed multithreaded module test cases

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -329,7 +329,6 @@ static int s_cAcquisitionsModule = 0;
 static std::mutex s_mutex;
 static std::condition_variable s_cv;
 static std::recursive_mutex s_mutexModule;
-static redisServerThreadVars vars;      /* Server thread local variables to be used by module threads */
 thread_local bool g_fModuleThread = false;
 
 typedef void (*RedisModuleForkDoneHandler) (int exitcode, int bysignal, void *user_data);
@@ -4775,7 +4774,7 @@ int moduleClientIsBlockedOnKeys(client *c) {
  * callback via RM_GetBlockedClientPrivateData). */
 int RM_UnblockClient(RedisModuleBlockedClient *bc, void *privdata) {
     if (serverTL == nullptr) {
-        serverTL = &vars;
+        serverTL = &g_pserver->modulethreadvar; 
         g_fModuleThread = true;
     }
     if (bc->blocked_on_keys) {
@@ -5058,7 +5057,7 @@ void RM_FreeThreadSafeContext(RedisModuleCtx *ctx) {
 void RM_ThreadSafeContextLock(RedisModuleCtx *ctx) {
     UNUSED(ctx);
     if (serverTL == nullptr) {
-        serverTL = &vars;
+        serverTL = &g_pserver->modulethreadvar;
         g_fModuleThread = true;
     }
     moduleAcquireGIL(FALSE /*fServerThread*/, true /*fExclusive*/);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -5885,6 +5885,8 @@ int main(int argc, char **argv) {
     {
         initServerThread(g_pserver->rgthreadvar+iel, iel == IDX_EVENT_LOOP_MAIN);
     }
+
+    initServerThread(&g_pserver->modulethreadvar, false);
     readOOMScoreAdj();
     initServer();
     initNetworking(cserver.cthreads > 1 /* fReusePort */);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2348,7 +2348,7 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
     locker.disarm();
     if (!fSentReplies)
         handleClientsWithPendingWrites(iel, aof_state);
-    if (moduleCount()) moduleReleaseGIL(TRUE /*fServerThread*/);
+    moduleReleaseGIL(TRUE /*fServerThread*/);
 
     /* Do NOT add anything below moduleReleaseGIL !!! */
 }
@@ -2361,7 +2361,7 @@ void afterSleep(struct aeEventLoop *eventLoop) {
     /* Do NOT add anything above moduleAcquireGIL !!! */
 
     /* Aquire the modules GIL so that their threads won't touch anything. */
-    if (moduleCount()) moduleAcquireGIL(TRUE /*fServerThread*/);
+    moduleAcquireGIL(TRUE /*fServerThread*/);
 }
 
 /* =========================== Server initialization ======================== */

--- a/src/server.h
+++ b/src/server.h
@@ -1491,6 +1491,7 @@ struct redisServer {
     ::dict *orig_commands;        /* Command table before command renaming. */
 
     struct redisServerThreadVars rgthreadvar[MAX_EVENT_LOOPS];
+    struct redisServerThreadVars modulethreadvar; /* Server thread local variables to be used by module threads */
     pthread_t rgthread[MAX_EVENT_LOOPS];
 
     std::atomic<unsigned int> lruclock;      /* Clock for LRU eviction */

--- a/src/server.h
+++ b/src/server.h
@@ -1389,6 +1389,8 @@ struct redisServerThreadVars {
     char neterr[ANET_ERR_LEN];   /* Error buffer for anet.c */
     long unsigned commandsExecuted = 0;
     bool fRetrySetAofEvent = false;
+    bool modulesEnabledThisAeLoop = false; /* In this loop of aeMain, were modules enabled before 
+                                              the thread went to sleep? */
     std::vector<client*> vecclientsProcess;
 };
 

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -25,6 +25,7 @@ TEST_MODULES = \
     auth.so \
     keyspace_events.so \
     blockedclient.so \
+    getkeys.so \
     timers.so
 
 


### PR DESCRIPTION
Module test cases should be working multithreaded now.

A summary of changes:
 -  Added getkeys test module back to module Makefile
 -  Properly initialize dedicated serverTL for modules, otherwise propagation doesn't work correctly in a module context
 -  Now threads will acquire the GIL upon waking up only if they released it prior to going to sleep 