### PR TITLE
fix for #323: seg fault on expiremember

### DIFF
--- a/src/expire.cpp
+++ b/src/expire.cpp
@@ -821,8 +821,8 @@ void expireEntryFat::expireSubKey(const char *szSubkey, long long when)
                     fFound = true;
                 }
                 if (fFound) {
-                    m_vecexpireEntries.erase(itr);
                     dictDelete(m_dictIndex, szSubkey);
+					m_vecexpireEntries.erase(itr);
                     break;
                 }
                 ++itr;

--- a/src/expire.cpp
+++ b/src/expire.cpp
@@ -822,7 +822,7 @@ void expireEntryFat::expireSubKey(const char *szSubkey, long long when)
                 }
                 if (fFound) {
                     dictDelete(m_dictIndex, szSubkey);
-					m_vecexpireEntries.erase(itr);
+                    m_vecexpireEntries.erase(itr);
                     break;
                 }
                 ++itr;


### PR DESCRIPTION
Fixes #323, caused by erasing a value from a vector before freeing the memory. The issue only pops up with too large a key space to make a test case feasible, however.