### PR TITLE
Backtrace for alpine using libunwind

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -127,7 +127,7 @@ ifneq ($(uname_S),Darwin)
 endif
 # Linux ARM32 needs -latomic at linking time
 ifneq (,$(findstring armv,$(uname_M)))
-        FINAL_LIBS+=-latomic
+	FINAL_LIBS+=-latomic
 endif
 
 
@@ -177,7 +177,7 @@ ifeq ($(uname_S),OpenBSD)
 	    FINAL_CXXFLAGS+= -DUSE_BACKTRACE -I/usr/local/include
 	    FINAL_LDFLAGS+= -L/usr/local/lib
 	    FINAL_LIBS+= -lexecinfo
-    	endif
+	endif
 
 else
 ifeq ($(uname_S),NetBSD)
@@ -187,7 +187,7 @@ ifeq ($(uname_S),NetBSD)
 	    FINAL_CFLAGS+= -DUSE_BACKTRACE -I/usr/pkg/include
 	    FINAL_LDFLAGS+= -L/usr/pkg/lib
 	    FINAL_LIBS+= -lexecinfo
-    	endif
+	endif
 else
 ifeq ($(uname_S),FreeBSD)
 	# FreeBSD
@@ -315,6 +315,13 @@ else
         $(INSTALL) $(1) $(2)
     endef
 endif
+
+OS := $(shell cat /etc/os-release | grep ID= | head -n 1 | cut -d'=' -f2)
+ifeq ($(OS),alpine)
+    FINAL_CXXFLAGS+=-DUNW_LOCAL_ONLY
+    FINAL_LIBS += -lunwind
+endif
+
 
 REDIS_CC=$(QUIET_CC)$(CC) $(FINAL_CFLAGS)
 REDIS_CXX=$(QUIET_CC)$(CXX) $(FINAL_CXXFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -316,6 +316,7 @@ else
     endef
 endif
 
+# Alpine OS doesn't have support for the execinfo backtrace library we use for debug, so we provide an alternate implementation using libwunwind.
 OS := $(shell cat /etc/os-release | grep ID= | head -n 1 | cut -d'=' -f2)
 ifeq ($(OS),alpine)
     FINAL_CXXFLAGS+=-DUNW_LOCAL_ONLY

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1610,7 +1610,7 @@ void safe_write(int fd, const void *pv, ssize_t cb)
  * The eip argument is unused as libunwind only gets local context.
  * The uplevel argument indicates how many of the calling functions to skip.
  */
-void logStackTrace(void * __unused eip, int uplevel) {
+void logStackTrace(UNUSED void * eip, int uplevel) {
     int fd = openDirectLogFiledes();
 
     if (fd == -1) return; /* If we can't log there is anything to do. */

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1612,14 +1612,22 @@ void safe_write(int fd, const void *pv, ssize_t cb)
  */
 void logStackTrace(void * eip, int uplevel) {
     (void)eip;//UNUSED
+    const char *msg;
     int fd = openDirectLogFiledes();
 
     if (fd == -1) return; /* If we can't log there is anything to do. */
+
+    msg = "\n------ STACK TRACE ------\n";
+    if (write(fd,msg,strlen(msg)) == -1) {/* Avoid warning. */};
     unw_cursor_t cursor;
     unw_context_t context;
 
     unw_getcontext(&context);
     unw_init_local(&cursor, &context);
+
+    /* Write symbols to log file */
+    msg = "\nBacktrace:\n";
+    if (write(fd,msg,strlen(msg)) == -1) {/* Avoid warning. */};
 
     for (int i = 0; i < uplevel; i++) {
         unw_step(&cursor);

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1606,7 +1606,11 @@ void safe_write(int fd, const void *pv, ssize_t cb)
 
 #ifdef UNW_LOCAL_ONLY
 
-void logStackTrace(void *eip, int uplevel) {
+/* Logs the stack trace using the libunwind call.
+ * The eip argument is unused as libunwind only gets local context.
+ * The uplevel argument indicates how many of the calling functions to skip.
+ */
+void logStackTrace(void * __unused eip, int uplevel) {
     int fd = openDirectLogFiledes();
 
     if (fd == -1) return; /* If we can't log there is anything to do. */

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1610,7 +1610,8 @@ void safe_write(int fd, const void *pv, ssize_t cb)
  * The eip argument is unused as libunwind only gets local context.
  * The uplevel argument indicates how many of the calling functions to skip.
  */
-void logStackTrace(UNUSED void * eip, int uplevel) {
+void logStackTrace(void * eip, int uplevel) {
+    (void)eip;//UNUSED
     int fd = openDirectLogFiledes();
 
     if (fd == -1) return; /* If we can't log there is anything to do. */

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -51,6 +51,7 @@ typedef ucontext_t sigcontext_t;
 #include <cxxabi.h>
 #endif /* HAVE_BACKTRACE */
 
+//UNW_LOCAL_ONLY being set means we use libunwind for backtraces instead of execinfo
 #ifdef UNW_LOCAL_ONLY
 #include <libunwind.h>
 #include <cxxabi.h>


### PR DESCRIPTION
Resolves issue #325. Ran make test on Ubuntu and Alpine, also ran custom test to compare backtraces from both platforms.
Ubuntu:
Backtrace:
./src/keydb-server *:6379(beforeSleep(aeEventLoop*)+0x4af) [0x55f3d2adc7bf]
./src/keydb-server *:6379(aeProcessEvents+0xe4) [0x55f3d2ad8404]
./src/keydb-server *:6379(aeMain+0x4b) [0x55f3d2ad89cb]
./src/keydb-server *:6379(workerThreadMain(void*)+0x74) [0x55f3d2ae01f4]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x9609) [0x7f532e176609]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x43) [0x7f532e09d293]
Alpine:
Backtrace:
beforeSleep(aeEventLoop*)(+0x4d8) [0x0000555d8deb5bf8] sp=0x00007f11223f20c0
aeProcessEvents(+0xde) [0x0000555d8deb19be] sp=0x00007f11223f2100
aeMain(+0x43) [0x0000555d8deb1ee3] sp=0x00007f11223f2180
workerThreadMain(void*)(+0x70) [0x0000555d8deb9810] sp=0x00007f11223f21a0
pthread_exit(+0x277) [0x00007f1123f141bb] sp=0x00007f11223f21c0