### PR TITLE
Add REPLPING command for use during replication

### DIFF
--- a/src/replication.cpp
+++ b/src/replication.cpp
@@ -2769,7 +2769,7 @@ void syncWithMaster(connection *conn) {
         mi->repl_state = REPL_STATE_RECEIVE_PING_REPLY;
         /* Send the PING, don't check for errors at all, we have the timeout
          * that will take care about this. */
-        err = sendCommand(conn,"PING",NULL);
+        err = sendCommand(conn,"REPLPING",NULL);
         if (err) goto write_error;
         return;
     }

--- a/src/replication.cpp
+++ b/src/replication.cpp
@@ -2785,7 +2785,7 @@ retry_connect:
          * permitted" instead of using a proper error code, so we test
          * both. */
         if (strncmp(err,"-ERR unknown command",20) == 0) {
-            serverLog(LL_WARNING,"Master does not support REPLPING, sending PING instead...");
+            serverLog(LL_NOTICE,"Master does not support REPLPING, sending PING instead...");
             mi->repl_state = REPL_STATE_RETRY_NOREPLPING;
             sdsfree(err);
             err = NULL;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -754,7 +754,7 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
      {"replping",pingCommand,-1,
-     "ok-stale ok-loading fast @connection @replication",
+     "ok-stale fast @connection @replication",
      0,NULL,0,0,0,0,0,0},
 
     {"echo",echoCommand,2,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -753,6 +753,10 @@ struct redisCommand redisCommandTable[] = {
      "ok-stale ok-loading fast @connection @replication",
      0,NULL,0,0,0,0,0,0},
 
+     {"replping",pingCommand,-1,
+     "ok-stale ok-loading fast @connection @replication",
+     0,NULL,0,0,0,0,0,0},
+
     {"echo",echoCommand,2,
      "fast @connection",
      0,NULL,0,0,0,0,0,0},
@@ -2768,6 +2772,7 @@ void createSharedObjects(void) {
     shared.lastid = makeObjectShared("LASTID",6);
     shared.default_username = makeObjectShared("default",7);
     shared.ping = makeObjectShared("ping",4);
+    shared.replping = makeObjectShared("replping", 8);
     shared.setid = makeObjectShared("SETID",5);
     shared.keepttl = makeObjectShared("KEEPTTL",7);
     shared.load = makeObjectShared("LOAD",4);

--- a/src/server.h
+++ b/src/server.h
@@ -505,6 +505,7 @@ typedef enum {
     REPL_STATE_NONE = 0,            /* No active replication */
     REPL_STATE_CONNECT,             /* Must connect to master */
     REPL_STATE_CONNECTING,          /* Connecting to master */
+    REPL_STATE_RETRY_NOREPLPING,    /* Master does not support REPLPING, retry with PING */
     /* --- Handshake states, must be ordered --- */
     REPL_STATE_RECEIVE_PING_REPLY,  /* Wait for PING reply */
     REPL_STATE_SEND_HANDSHAKE,      /* Send handshake sequance to master */

--- a/src/server.h
+++ b/src/server.h
@@ -1283,7 +1283,7 @@ struct sharedObjectsStruct {
     *emptyscan, *multi, *exec, *left, *right, *hset, *srem, *xgroup, *xclaim,  
     *script, *replconf, *eval, *persist, *set, *pexpireat, *pexpire, 
     *time, *pxat, *px, *retrycount, *force, *justid, 
-    *lastid, *ping, *setid, *keepttl, *load, *createconsumer,
+    *lastid, *ping, *replping, *setid, *keepttl, *load, *createconsumer,
     *getack, *special_asterick, *special_equals, *default_username,
     *hdel, *zrem, *mvccrestore, *pexpirememberat,
     *select[PROTO_SHARED_SELECT_CMDS],


### PR DESCRIPTION
Adds a REPLPING command that gets sent during the replication handshake. The loading server recognizes this and responds when it's busy to prevent disconnection. If the command is not supported, PING is instead used.

The reason for this change is to fix load balancers, which rely on PING not being allowed during loading. Thus PING is reverted back to remove the `ok-loading` flag.