### PR TITLE
Prevent invalid mvcc timestamps from causing critical errors

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -5167,11 +5167,12 @@ void dumpCommand(client *c) {
 
 /* KEYDB.MVCCRESTORE key mvcc expire serialized-value */
 void mvccrestoreCommand(client *c) {
-    long long mvcc, expire;
+    long long expire;
+    uint64_t mvcc;
     robj *key = c->argv[1], *obj = nullptr;
     int type;
     
-    if (getLongLongFromObjectOrReply(c, c->argv[2], &mvcc, "Invalid MVCC Tstamp") != C_OK)
+    if (getUnsignedLongLongFromObjectOrReply(c, c->argv[2], &mvcc, "Invalid MVCC Tstamp") != C_OK)
         return;
 
     if (getLongLongFromObjectOrReply(c, c->argv[3], &expire, "Invalid expire") != C_OK)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -763,6 +763,20 @@ int getLongLongFromObjectOrReply(client *c, robj *o, long long *target, const ch
     return C_OK;
 }
 
+int getUnsignedLongLongFromObjectOrReply(client *c, robj *o, uint64_t *target, const char *msg) {
+    uint64_t value;
+    if (getUnsignedLongLongFromObject(o, &value) != C_OK) {
+        if (msg != NULL) {
+            addReplyError(c,(char*)msg);
+        } else {
+            addReplyError(c,"value is not an integer or out of range");
+        }
+        return C_ERR;
+    }
+    *target = value;
+    return C_OK;
+}
+
 int getLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg) {
     long long value;
 

--- a/src/server.h
+++ b/src/server.h
@@ -2376,6 +2376,7 @@ robj *createZsetZiplistObject(void);
 robj *createStreamObject(void);
 robj *createModuleObject(moduleType *mt, void *value);
 int getLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
+int getUnsignedLongLongFromObjectOrReply(client *c, robj *o, uint64_t *target, const char *msg);
 int getPositiveLongFromObjectOrReply(client *c, robj *o, long *target, const char *msg);
 int getRangeLongFromObjectOrReply(client *c, robj *o, long min, long max, long *target, const char *msg);
 int checkType(client *c, robj_roptr o, int type);


### PR DESCRIPTION
MVCC timestamps were being parsed as long longs, but MVCC invalid timestamps were appearing as UNSIGNED_LONG_MAX. This caused the parsing to fail and subsequently throwing a critical error for each key without a valid MVCC timestamp. 

Fix was to change the parsing to unsigned long instead (which matches the uint64_t datatype of MVCC timestamps)