### PR TITLE
Fix and expand 32-bit build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
+          sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get -y install uuid-dev libcurl4-openssl-dev
+          sudo apt-get -y install gcc-multilib g++-multilib libc6-dev-i386 lib32z1 uuid-dev:i386 libcurl4-openssl-dev:i386
           make KEYDB_CFLAGS='-Werror' KEYDB_CXXFLAGS='-Werror' 32bit -j2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,13 @@ jobs:
           sudo apt-get -y install uuid-dev libcurl4-openssl-dev
           make KEYDB_CFLAGS='-Werror' KEYDB_CXXFLAGS='-Werror' MALLOC=libc -j2
 
+  build-ubuntu-32bit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+          sudo apt-get update
+          sudo apt-get -y install uuid-dev libcurl4-openssl-dev
+          make KEYDB_CFLAGS='-Werror' KEYDB_CXXFLAGS='-Werror' 32bit -j2
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -70,7 +70,7 @@ endif
 # Do we use our assembly spinlock? X64 only
 ifeq ($(uname_S),Linux)
 ifeq ($(uname_M),x86_64)
-ifneq ($(@@),32bit)
+ifneq ($(TARGET32), true)
 ifeq ($(USEASM),true)
 	ASM_OBJ+= fastlock_x64.o
 	CFLAGS+= -DASM_SPINLOCK
@@ -484,7 +484,7 @@ bench: $(REDIS_BENCHMARK_NAME)
 	@echo ""
 	@echo "WARNING: if it fails under Linux you probably need to install libc6-dev-i386"
 	@echo ""
-	$(MAKE) CXXFLAGS="-m32" CFLAGS="-m32" LDFLAGS="-m32"
+	$(MAKE) CXXFLAGS="-m32" CFLAGS="-m32" LDFLAGS="-m32" TARGET32=true
 
 gcov:
 	$(MAKE) KEYDB_CXXFLAGS="-fprofile-arcs -ftest-coverage -DCOVERAGE_TEST" KEYDB_CFLAGS="-fprofile-arcs -ftest-coverage -DCOVERAGE_TEST" KEYDB_LDFLAGS="-fprofile-arcs -ftest-coverage"

--- a/src/rio.h
+++ b/src/rio.h
@@ -63,7 +63,7 @@ struct _rio {
     uint64_t cksum, flags;
 
     /* number of keys loaded since last rdbLoadProgressCallback */
-    long int keys_since_last_callback;
+    unsigned long int keys_since_last_callback;
 
     /* number of bytes read or written */
     size_t processed_bytes;

--- a/src/semiorderedset.h
+++ b/src/semiorderedset.h
@@ -247,8 +247,8 @@ public:
         /* Generate human readable stats. */
         l += snprintf(buf+l,bufsize-l,
             "semiordered set stats:\n"
-            " table size: %ld\n"
-            " number of slots: %ld\n"
+            " table size: %zu\n"
+            " number of slots: %zu\n"
             " used slots: %ld\n"
             " max chain length: %ld\n"
             " avg chain length (counted): %.02f\n"

--- a/src/server.h
+++ b/src/server.h
@@ -901,7 +901,7 @@ public:
     void addref() const { refcount.fetch_add(1, std::memory_order_relaxed); }
     unsigned release() const { return refcount.fetch_sub(1, std::memory_order_seq_cst) & ~(1U << 31); }
 } robj;
-static_assert(sizeof(redisObject) == 16, "object size is critical, don't increase");
+static_assert(sizeof(redisObject) <= 16, "object size is critical, don't increase");
 
 class redisObjectStack : public redisObjectExtended, public redisObject
 {


### PR DESCRIPTION
32-bit builds previously failed. This change fixes the bug (an overly strict static assert), changes the 32bit make target to function correctly, fixes warnings only present in 32-bit builds, and adds a 32-bit Github action to verify the build.

Fixes #336 and #240.