### PR TITLE
syslog: enforce syslog identity and facility as soon as possible

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3498,11 +3498,6 @@ void initServer(void) {
             selectDb(mi->cached_master, 0);
     }
 
-    if (g_pserver->syslog_enabled) {
-        openlog(g_pserver->syslog_ident, LOG_PID | LOG_NDELAY | LOG_NOWAIT,
-            g_pserver->syslog_facility);
-    }
-
     g_pserver->aof_state = g_pserver->aof_enabled ? AOF_ON : AOF_OFF;
     g_pserver->hz = g_pserver->config_hz;
     cserver.pid = getpid();
@@ -6780,6 +6775,11 @@ int main(int argc, char **argv) {
         loadServerConfig(cserver.configfile, config_from_stdin, options);
         if (g_pserver->sentinel_mode) loadSentinelConfigFromQueue();
         sdsfree(options);
+    }
+
+    if (g_pserver->syslog_enabled) {
+        openlog(g_pserver->syslog_ident, LOG_PID | LOG_NDELAY | LOG_NOWAIT,
+            g_pserver->syslog_facility);
     }
 
     if (cserver.fUsePro) {


### PR DESCRIPTION
Else syslog identity and facility aren't enforce for first log messages.

Without this patch:
```
août 30 23:50:27 keydb-server[23008]: oO0OoO0OoO0Oo KeyDB is starting oO0OoO0OoO0Oo
août 30 23:50:27 keydb-server[23008]: KeyDB version=255.255.255, bits=64, commit=0be40b9f, modified=0, pid=23008, just started
août 30 23:50:27 keydb-server[23008]: Configuration loaded
août 30 23:50:27 toto[23008]: Increased maximum number of open files to 10032 (it was originally set to 1024).
août 30 23:50:27 toto[23008]: monotonic clock: POSIX clock_gettime
août 30 23:50:27 toto[23008]: Running mode=standalone, port=6379.
…
```

With this patch:
```
août 31 00:04:44 mde-claranet toto[23714]: oO0OoO0OoO0Oo KeyDB is starting oO0OoO0OoO0Oo
août 31 00:04:44 mde-claranet toto[23714]: KeyDB version=255.255.255, bits=64, commit=0be40b9f, modified=1, pid=23714, just started
août 31 00:04:44 mde-claranet toto[23714]: Configuration loaded
août 31 00:04:44 mde-claranet toto[23714]: Increased maximum number of open files to 10032 (it was originally set to 1024).
août 31 00:04:44 mde-claranet toto[23714]: monotonic clock: POSIX clock_gettime
août 31 00:04:44 mde-claranet toto[23714]: Running mode=standalone, port=6379.
…
```