### PR TITLE
use LL_… log level instead of syslog LOG_… log level

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -359,7 +359,7 @@ static int updateOOMScoreAdjValues(sds *args, const char **err, int apply) {
 
     if (values[CONFIG_OOM_REPLICA] < values[CONFIG_OOM_MASTER] ||
         values[CONFIG_OOM_BGCHILD] < values[CONFIG_OOM_REPLICA]) {
-            serverLog(LOG_WARNING,
+            serverLog(LL_WARNING,
                     "The oom-score-adj-values configuration may not work for non-privileged processes! "
                     "Please consult the documentation.");
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3091,7 +3091,7 @@ int setOOMScoreAdj(int process_class) {
 
     fd = open("/proc/self/oom_score_adj", O_WRONLY);
     if (fd < 0 || write(fd, buf, strlen(buf)) < 0) {
-        serverLog(LOG_WARNING, "Unable to write oom_score_adj: %s", strerror(errno));
+        serverLog(LL_WARNING, "Unable to write oom_score_adj: %s", strerror(errno));
         if (fd != -1) close(fd);
         return C_ERR;
     }
@@ -6538,7 +6538,7 @@ void OnTerminate()
 void *workerThreadMain(void *parg)
 {
     int iel = (int)((int64_t)parg);
-    serverLog(LOG_INFO, "Thread %d alive.", iel);
+    serverLog(LL_NOTICE, "Thread %d alive.", iel);
     serverTL = g_pserver->rgthreadvar+iel;  // set the TLS threadsafe global
     tlsInitThread();
 
@@ -6940,7 +6940,7 @@ int main(int argc, char **argv) {
             CPU_SET(iel + cserver.threadAffinityOffset, &cpuset);
             if (pthread_setaffinity_np(g_pserver->rgthread[iel], sizeof(cpu_set_t), &cpuset) == 0)
             {
-                serverLog(LOG_INFO, "Binding thread %d to cpu %d", iel, iel + cserver.threadAffinityOffset + 1);
+                serverLog(LL_NOTICE, "Binding thread %d to cpu %d", iel, iel + cserver.threadAffinityOffset + 1);
             }
 #else
 			serverLog(LL_WARNING, "CPU pinning not available on this platform");

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -109,7 +109,7 @@ void pool_free(struct alloc_pool *ppool, void *pv)
         }
         cur = cur->pnext;
     }
-    serverLog(LOG_CRIT, "obj not from pool");
+    serverLog(LL_WARNING, "obj not from pool");
     sfree(obj); // we don't know where it came from
     return;
 }
@@ -151,14 +151,14 @@ void storage_init(const char *tmpfilePath, size_t cbFileReserve)
         int errv = memkind_create_pmem(PMEM_DIR, 0, &mkdisk);
         if (errv == MEMKIND_ERROR_INVALID)
         {
-            serverLog(LOG_CRIT, "Memory pool creation failed: %s", strerror(errno));
+            serverLog(LL_WARNING, "Memory pool creation failed: %s", strerror(errno));
             exit(EXIT_FAILURE);
         }
         else if (errv)
         {
             char msgbuf[1024];
             memkind_error_message(errv, msgbuf, 1024);
-            serverLog(LOG_CRIT, "Memory pool creation failed: %s", msgbuf);
+            serverLog(LL_WARNING, "Memory pool creation failed: %s", msgbuf);
             exit(EXIT_FAILURE);
         }
 
@@ -166,7 +166,7 @@ void storage_init(const char *tmpfilePath, size_t cbFileReserve)
         int fdTest = forkFile();
         if (fdTest < 0)
         {
-            serverLog(LOG_ERR, "Scratch file system does not support Copy on Write.  To fix this scratch-file-path must point to a path on a filesystem which supports copy on write, such as btrfs.");
+            serverLog(LL_WARNING, "Scratch file system does not support Copy on Write.  To fix this scratch-file-path must point to a path on a filesystem which supports copy on write, such as btrfs.");
             exit(EXIT_FAILURE);
         }
         close(fdTest);
@@ -254,7 +254,7 @@ void handle_prefork()
 {
     fdNew = forkFile();
     if (fdNew < 0)
-        serverLog(LOG_ERR, "Failed to clone scratch file");
+        serverLog(LL_WARNING, "Failed to clone scratch file");
 }
 
 void handle_postfork_parent()


### PR DESCRIPTION
Else there is an out of bound access in syslogLevelMap.

For example if we use `serverLog(LOG_INFO,…`, later in the code
it tries to access `syslogLevelMap[LOG_INFO]`.
LOG_INFO == 6 but syslogLevelMap only have 4 elements.