### PR TITLE
Fix alignment of #ifndef USE_ALIGNED_ACCESS in bitops.cpp

### DIFF
--- a/src/bitops.cpp
+++ b/src/bitops.cpp
@@ -800,8 +800,8 @@ void bitopCommand(client *c) {
                     }
                 }
             }
+            #endif
         }
-        #endif
 
         /* j is set to the next byte to process by the previous loop. */
         for (; j < maxlen; j++) {


### PR DESCRIPTION
If USE_ALIGNED_ACCESS is set, the curly braces become uneven and it breaks the compilation on some targets. 

```c++
bitops.cpp: In function 'void bitopCommand(client*)':
bitops.cpp:734:27: warning: unused variable 'i' [-Wunused-variable]
  734 |             unsigned long i;
      |                           ^
bitops.cpp:856:33: error: a function-definition is not allowed here before '{' token
  856 | void bitcountCommand(client *c) {
      |                                 ^
bitops.cpp:905:31: error: a function-definition is not allowed here before '{' token
  905 | void bitposCommand(client *c) {
      |                               ^
bitops.cpp:1007:44: error: a function-definition is not allowed here before '{' token
 1007 | void bitfieldGeneric(client *c, int flags) {
      |                                            ^
bitops.cpp:1232:33: error: a function-definition is not allowed here before '{' token
 1232 | void bitfieldCommand(client *c) {
      |                                 ^
bitops.cpp:1236:35: error: a function-definition is not allowed here before '{' token
 1236 | void bitfieldroCommand(client *c) {
      |                                   ^
bitops.cpp:1238:1: error: expected '}' at end of input
 1238 | }
      | ^
bitops.cpp:595:30: note: to match this '{'
  595 | void bitopCommand(client *c) {
      |                              ^
```