### PR TITLE
Draft: Namespaces

### DIFF
--- a/src/acl.cpp
+++ b/src/acl.cpp
@@ -1134,6 +1134,8 @@ int ACLAuthenticateUser(client *c, robj *username, robj *password) {
     if (ACLCheckUserCredentials(username,password) == C_OK) {
         c->authenticated = 1;
         c->user = ACLGetUserByName((sds)ptrFromObj(username),sdslen((sds)ptrFromObj(username)));
+        c->ns = getNamespace(c->user->ns_name);
+        selectDbNamespaced(c, c->db->mapped_id);
         moduleNotifyUserChanged(c);
         return C_OK;
     } else {

--- a/src/aof.cpp
+++ b/src/aof.cpp
@@ -771,8 +771,8 @@ void feedAppendOnlyFile(struct redisCommand *cmd, int dictid, robj **argv, int a
 struct client *createAOFClient(void) {
     struct client *c =(client*) zmalloc(sizeof(*c), MALLOC_LOCAL);
 
-    selectDb(c,0);
     c->ns = g_pserver->default_namespace;
+    selectDbNamespaced(c, 0);
     c->id = CLIENT_ID_AOF; /* So modules can identify it's the AOF client. */
     c->conn = NULL;
     c->iel = IDX_EVENT_LOOP_MAIN;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -209,6 +209,7 @@ typedef struct {
 } clusterMsgDataFail;
 
 typedef struct {
+    uint32_t ns_len;
     uint32_t channel_len;
     uint32_t message_len;
     unsigned char bulk_data[8]; /* 8 bytes just as placeholder. */

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2671,7 +2671,7 @@ standardConfig configs[] = {
     createStringConfig("bgsave_cpulist", NULL, IMMUTABLE_CONFIG, EMPTY_STRING_IS_NULL, g_pserver->bgsave_cpulist, NULL, NULL, NULL),
     createStringConfig("ignore-warnings", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, g_pserver->ignore_warnings, "", NULL, NULL),
     createStringConfig("proc-title-template", NULL, MODIFIABLE_CONFIG, ALLOW_EMPTY_STRING, cserver.proc_title_template, CONFIG_DEFAULT_PROC_TITLE_TEMPLATE, isValidProcTitleTemplate, updateProcTitleTemplate),
-
+    createStringConfig("acl-namespace-default", NULL, IMMUTABLE_CONFIG, ALLOW_EMPTY_STRING, cserver.default_user_namespace, "::", NULL, NULL), //TODO: validation
     /* SDS Configs */
     createSDSConfig("masterauth", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, cserver.default_masterauth, NULL, NULL, updateMasterAuthConfig),
     createSDSConfig("requirepass", NULL, MODIFIABLE_CONFIG | SENSITIVE_CONFIG, EMPTY_STRING_IS_NULL, g_pserver->requirepass, NULL, NULL, updateRequirePass),

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -542,7 +542,11 @@ void loadServerConfigFromString(char *config) {
             if (port < 0 || port > 65535 || *ptr != '\0') {
                 err= "Invalid master port"; goto loaderr;
             }
-            replicationAddMaster(argv[1], port);
+
+            redisMasterConnInfo *masterInfo = (redisMasterConnInfo*)zmalloc(sizeof(redisMasterConnInfo), MALLOC_LOCAL);
+            masterInfo->ip = sdsnew(argv[1]);
+            masterInfo->port = port;
+            listAddNodeTail(g_pserver->repl_init_masters, masterInfo);
         } else if (!strcasecmp(argv[0],"requirepass") && argc == 2) {
             if (strlen(argv[1]) > CONFIG_AUTHPASS_MAX_LEN) {
                 err = "Password is longer than CONFIG_AUTHPASS_MAX_LEN";

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2685,6 +2685,7 @@ standardConfig configs[] = {
 
     /* Integer configs */
     createIntConfig("databases", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, cserver.dbnum, 16, INTEGER_CONFIG, NULL, NULL),
+    createIntConfig("databases-per-namespace", NULL, IMMUTABLE_CONFIG, 1, INT_MAX, cserver.ns_dbnum, INT_MAX, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("port", NULL, MODIFIABLE_CONFIG, 0, 65535, g_pserver->port, 6379, INTEGER_CONFIG, NULL, updatePort), /* TCP port. */
     createIntConfig("auto-aof-rewrite-percentage", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, g_pserver->aof_rewrite_perc, 100, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("cluster-replica-validity-factor", "cluster-slave-validity-factor", MODIFIABLE_CONFIG, 0, INT_MAX, g_pserver->cluster_slave_validity_factor, 10, INTEGER_CONFIG, NULL, NULL), /* Slave max data age factor. */

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -681,6 +681,24 @@ void mapDb(redisNamespace *ns, int global_db, int ns_db, int do_propagate) {
     }
 }
 
+void printDbMap() {
+    serverLog(LL_NOTICE, "------ database mapping ------");
+    for (int i=0; i<cserver.dbnum;i++) {
+        serverLog(LL_NOTICE, "%d => %d (%s) @ %d keys", i, g_pserver->db[i].mapped_id,
+                  g_pserver->db[i].ns ? g_pserver->db[i].ns->name : "<none>", (int) dictSize(g_pserver->db[i].dict));
+    }
+    serverLog(LL_NOTICE, "------ default ns mapping ------");
+    for (int i=0; i<std::min(cserver.dbnum,cserver.ns_dbnum);i++) {
+        if (g_pserver->default_namespace->db[i]) {
+            serverLog(LL_NOTICE, "%d => %d (%s) @ %d keys", i, g_pserver->default_namespace->db[i]->mapped_id,
+                      g_pserver->default_namespace->db[i]->ns ? g_pserver->default_namespace->db[i]->ns->name
+                                                              : "<none>",
+                      (int) dictSize(g_pserver->default_namespace->db[i]->dict));
+        }
+    }
+    serverLog(LL_NOTICE, "---- end database mapping ----");
+}
+
 redisDb *allocateDb(client *c, int id) {
     if (id < 0 || id >= std::min(cserver.dbnum, cserver.ns_dbnum)) return nullptr;
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -649,7 +649,7 @@ int selectDb(client *c, int id) {
 void mapDb(redisNamespace *ns, int global_db, int ns_db) {
     serverAssert(global_db >= 0 && global_db < cserver.dbnum);
     serverAssert(ns_db >= 0 &&  ns_db < std::min(cserver.dbnum, cserver.ns_dbnum));
-    serverAssert(!g_pserver->db[global_db].ns);
+    serverAssert(!g_pserver->db[global_db].ns || (g_pserver->db[global_db].ns == ns && g_pserver->db[global_db].mapped_id == ns_db));
     //TODO: locking?
     g_pserver->db[global_db].ns = ns;
     g_pserver->db[global_db].mapped_id = ns_db;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -499,6 +499,7 @@ long long emptyDbStructure(redisDb *dbarray, int dbnum, int async,
             dbarray[j].ns->db[dbarray[j].mapped_id] = nullptr;
             dbarray[j].mapped_id = -1;
             dbarray[j].ns = nullptr;
+            g_pserver->last_allocated_db = -1;
         }
     }
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -930,6 +930,12 @@ void selectCommand(client *c) {
     }
 }
 
+void selectNsCommand(client *c) {
+    //TODO: validate namespace name
+    c->ns = getNamespace(szFromObj(c->argv[2]));
+    selectCommand(c);
+}
+
 void allocateCommand(client *c) {
     int global_db, ns_db;
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -567,9 +567,17 @@ NULL
         serverLog(LL_WARNING,"DB reloaded by DEBUG RELOAD");
         addReply(c,shared.ok);
     } else if (!strcasecmp(szFromObj(c->argv[1]),"loadaof")) {
+        serverLog(LL_WARNING,"Append Only File loaded by DEBUG LOADAOF started");
         if (g_pserver->aof_state != AOF_OFF) flushAppendOnlyFile(1);
         emptyDb(-1,EMPTYDB_NO_FLAGS,NULL);
         protectClient(c);
+        for (int i=0; i<cserver.dbnum; i++) {
+            if (g_pserver->db[i].ns) {
+                g_pserver->db[i].ns->db[g_pserver->db[i].mapped_id] = nullptr;
+                g_pserver->db[i].mapped_id = -1;
+                g_pserver->db[i].ns = nullptr;
+            }
+        }
         int ret = loadAppendOnlyFile(g_pserver->aof_filename);
         unprotectClient(c);
         if (ret != C_OK) {
@@ -577,7 +585,7 @@ NULL
             return;
         }
         g_pserver->dirty = 0; /* Prevent AOF / replication */
-        serverLog(LL_WARNING,"Append Only File loaded by DEBUG LOADAOF");
+        serverLog(LL_WARNING,"Append Only File loaded by DEBUG LOADAOF done");
         addReply(c,shared.ok);
     } else if (!strcasecmp(szFromObj(c->argv[1]),"object") && c->argc == 3) {
         dictEntry *de;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -974,6 +974,7 @@ void _serverAssertPrintClientInfo(const client *c) {
 
     bugReportStart();
     serverLog(LL_WARNING,"=== ASSERTION FAILED CLIENT CONTEXT ===");
+    serverLog(LL_WARNING,"client->id = %llu", (unsigned long long) c->id);
     serverLog(LL_WARNING,"client->flags = %llu", (unsigned long long) c->flags);
     serverLog(LL_WARNING,"client->conn = %s", connGetInfo(c->conn, conninfo, sizeof(conninfo)));
     serverLog(LL_WARNING,"client->argc = %d", c->argc);
@@ -1037,6 +1038,7 @@ void _serverAssertPrintObject(robj_roptr o) {
 void _serverAssertWithInfo(const client *c, robj_roptr o, const char *estr, const char *file, int line) {
     if (c) _serverAssertPrintClientInfo(c);
     if (o) _serverAssertPrintObject(o);
+    printDbMap();
     _serverAssert(estr,file,line);
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -848,18 +848,18 @@ NULL
             sdsfree(stats);
             return;
         }
-        if (dbid < 0 || dbid >= cserver.dbnum) {
+        if (dbid < 0 || dbid >= std::min(cserver.dbnum, cserver.ns_dbnum)) {
             sdsfree(stats);
             addReplyError(c,"Out of range database");
             return;
         }
 
         stats = sdscatprintf(stats,"[Dictionary HT]\n");
-        dictGetStats(buf,sizeof(buf),g_pserver->db[dbid].dict);
+        dictGetStats(buf,sizeof(buf),c->ns->db[dbid]->dict);
         stats = sdscat(stats,buf);
 
         stats = sdscatprintf(stats,"[Expires set]\n");
-        g_pserver->db[dbid].setexpire->getstats(buf, sizeof(buf));
+        c->ns->db[dbid]->setexpire->getstats(buf, sizeof(buf));
         stats = sdscat(stats, buf);
 
         addReplyVerbatim(c,stats,sdslen(stats),"txt");

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -571,13 +571,7 @@ NULL
         if (g_pserver->aof_state != AOF_OFF) flushAppendOnlyFile(1);
         emptyDb(-1,EMPTYDB_NO_FLAGS,NULL);
         protectClient(c);
-        for (int i=0; i<cserver.dbnum; i++) {
-            if (g_pserver->db[i].ns) {
-                g_pserver->db[i].ns->db[g_pserver->db[i].mapped_id] = nullptr;
-                g_pserver->db[i].mapped_id = -1;
-                g_pserver->db[i].ns = nullptr;
-            }
-        }
+
         int ret = loadAppendOnlyFile(g_pserver->aof_filename);
         unprotectClient(c);
         if (ret != C_OK) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2097,10 +2097,9 @@ int RM_GetClientInfoById(void *ci, uint64_t id) {
 
 /* Publish a message to subscribers (see PUBLISH command). */
 int RM_PublishMessage(RedisModuleCtx *ctx, RedisModuleString *channel, RedisModuleString *message) {
-    UNUSED(ctx);
-    int receivers = pubsubPublishMessage(channel, message);
+    int receivers = pubsubPublishMessage(ctx->client->ns, channel, message);
     if (g_pserver->cluster_enabled)
-        clusterPropagatePublish(channel, message);
+        clusterPropagatePublish(ctx->client->ns, channel, message);
     return receivers;
 }
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2512,7 +2512,7 @@ int RM_SetAbsExpire(RedisModuleKey *key, mstime_t expire) {
  * When async is set to true, db contents will be freed by a background thread. */
 void RM_ResetDataset(int restart_aof, int async) {
     if (restart_aof && g_pserver->aof_state != AOF_OFF) stopAppendOnly();
-    flushAllDataAndResetRDB(async? EMPTYDB_ASYNC: EMPTYDB_NO_FLAGS);
+    flushAllDataAndResetRDB(NULL, async? EMPTYDB_ASYNC: EMPTYDB_NO_FLAGS);
     if (g_pserver->aof_enabled && restart_aof) restartAOFAfterSYNC();
 }
 
@@ -4214,6 +4214,7 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
     /* We do not want to allow block, the module do not expect it */
     c->flags |= CLIENT_DENY_BLOCKING;
     c->db = ctx->client->db;
+    c->ns = ctx->client->ns;
     c->argv = argv;
     c->argc = argc;
     if (ctx->module) ctx->module->in_call++;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -2292,7 +2292,7 @@ int RM_AvoidReplicaTraffic() {
  * returns back to the original one, it should call RedisModule_GetSelectedDb()
  * before in order to restore the old DB number before returning. */
 int RM_SelectDb(RedisModuleCtx *ctx, int newid) {
-    int retval = selectDb(ctx->client,newid);
+    int retval = selectDbNamespaced(ctx->client,newid);
     return (retval == C_OK) ? REDISMODULE_OK : REDISMODULE_ERR;
 }
 
@@ -8526,7 +8526,7 @@ void moduleFireServerEvent(uint64_t eid, int subid, void *data) {
              * up to the specific event setup to change it when it makes
              * sense. For instance for FLUSHDB events we select the correct
              * DB automatically. */
-            selectDb(ctx.client, 0);
+            selectDbNamespaced(ctx.client, 0);
 
             /* Event specific context and data pointer setup. */
             if (eid == REDISMODULE_EVENT_CLIENT_CHANGE) {

--- a/src/networking.cpp
+++ b/src/networking.cpp
@@ -2733,7 +2733,7 @@ sds catClientInfoString(sds s, client *client) {
         total_mem += zmalloc_size(client->argv);
 
     return sdscatfmt(s,
-        "id=%U addr=%s laddr=%s %s name=%s age=%I idle=%I flags=%s db=%i sub=%i psub=%i multi=%i qbuf=%U qbuf-free=%U argv-mem=%U obl=%U oll=%U omem=%U tot-mem=%U events=%s cmd=%s user=%s redir=%I ns=%s",
+        "id=%U addr=%s laddr=%s %s name=%s age=%I idle=%I flags=%s db=%i(%i) sub=%i psub=%i multi=%i qbuf=%U qbuf-free=%U argv-mem=%U obl=%U oll=%U omem=%U tot-mem=%U events=%s cmd=%s user=%s redir=%I ns=%s",
         (unsigned long long) client->id,
         getClientPeerId(client),
         getClientSockname(client),
@@ -2743,6 +2743,7 @@ sds catClientInfoString(sds s, client *client) {
         (long long)(g_pserver->unixtime - client->lastinteraction),
         flags,
         client->db->mapped_id,
+        client->db->id,
         (int) dictSize(client->pubsub_channels),
         (int) listLength(client->pubsub_patterns),
         (client->flags & CLIENT_MULTI) ? client->mstate.count : -1,
@@ -2757,7 +2758,7 @@ sds catClientInfoString(sds s, client *client) {
         client->lastcmd ? client->lastcmd->name : "NULL",
         client->user ? client->user->name : "(superuser)",
         (client->flags & CLIENT_TRACKING) ? (long long) client->client_tracking_redirection : -1,
-        client->ns->name);
+        client->ns ? client->ns->name : "(unset)");
 }
 
 sds getAllClientsInfoString(int type) {

--- a/src/networking.cpp
+++ b/src/networking.cpp
@@ -140,7 +140,6 @@ client *createClient(connection *conn, int iel) {
         connSetPrivateData(conn, c);
     }
 
-    selectDb(c,0);
     uint64_t client_id;
     client_id = g_pserver->next_client_id.fetch_add(1);
     c->iel = iel;
@@ -173,6 +172,7 @@ client *createClient(connection *conn, int iel) {
     /* If the default user does not require authentication, the user is
      * directly authenticated. */
     clientSetDefaultAuth(c);
+    selectDbNamespaced(c,0);
     c->replstate = REPL_STATE_NONE;
     c->repl_put_online_on_ack = 0;
     c->reploff = 0;
@@ -2838,7 +2838,7 @@ void resetCommand(client *c) {
     }
 
     if (c->flags & CLIENT_TRACKING) disableTracking(c);
-    selectDb(c,0);
+
     c->resp = 2;
 
     clientSetDefaultAuth(c);
@@ -2849,6 +2849,7 @@ void resetCommand(client *c) {
     pubsubUnsubscribeAllPatterns(c,0);
 
     c->ns = g_pserver->default_namespace;
+    selectDbNamespaced(c,0);
 
     if (c->name) {
         decrRefCount(c->name);

--- a/src/rdb.cpp
+++ b/src/rdb.cpp
@@ -1303,6 +1303,9 @@ int rdbSaveRio(rio *rdb, int *error, int rdbflags, rdbSaveInfo *rsi) {
         redisDb *db = g_pserver->db+j;
         dict *d = db->dict;
         if (dictSize(d) == 0) continue;
+        serverAssert(db->ns);
+        serverAssert(db->mapped_id >= 0);
+
         di = dictGetSafeIterator(d);
 
         /* Write the SELECT DB opcode */

--- a/src/replication.cpp
+++ b/src/replication.cpp
@@ -3285,7 +3285,8 @@ void freeMasterInfo(redisMaster *mi)
     zfree(mi->masteruser);
     if (mi->repl_transfer_tmpfile)
         zfree(mi->repl_transfer_tmpfile);
-    delete mi->staleKeyMap;
+    if (mi->staleKeyMap != nullptr)
+        delete mi->staleKeyMap;
     if (mi->cached_master != nullptr)
         freeClientAsync(mi->cached_master);
     if (mi->master != nullptr)

--- a/src/replication.cpp
+++ b/src/replication.cpp
@@ -4697,6 +4697,7 @@ void replicaReplayCommand(client *c)
     cFake->lock.lock();
     cFake->authenticated = c->authenticated;
     cFake->user = c->user;
+    cFake->ns = c->ns;
     cFake->querybuf = sdscatsds(cFake->querybuf,(sds)ptrFromObj(c->argv[2]));
     selectDb(cFake, c->db->id);
     auto ccmdPrev = serverTL->commandsExecuted;

--- a/src/scripting.cpp
+++ b/src/scripting.cpp
@@ -605,6 +605,7 @@ int luaRedisGenericCommand(lua_State *lua, int raise_error) {
     c->argv = argv;
     c->argc = argc;
     c->user = g_pserver->lua_caller->user;
+    c->ns = g_pserver->lua_caller->ns;
 
     /* Process module hooks */
     moduleCallCommandFilters(c);

--- a/src/sentinel.cpp
+++ b/src/sentinel.cpp
@@ -734,7 +734,7 @@ void sentinelEvent(int level, const char *type, sentinelRedisInstance *ri,
     if (level != LL_DEBUG) {
         channel = createStringObject(type,strlen(type));
         payload = createStringObject(msg,strlen(msg));
-        pubsubPublishMessage(channel,payload);
+        pubsubPublishMessage(g_pserver->default_namespace, channel,payload);
         decrRefCount(channel);
         decrRefCount(payload);
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3530,6 +3530,7 @@ void initDb(void) {
     g_pserver->namespaces = dictCreate(&namespaceDictType,NULL);
     g_pserver->default_namespace = getNamespace("::");
     g_pserver->db = (redisDb*)zmalloc(sizeof(redisDb)*cserver.dbnum, MALLOC_LOCAL);
+    g_pserver->last_allocated_db = -1;
 
     /* Create the Redis databases, and initialize other internal state. */
     for (int j = 0; j < cserver.dbnum; j++) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3492,6 +3492,19 @@ static void initServerThread(struct redisServerThreadVars *pvar, int fMain)
     }
 }
 
+sds generateAutoNamespaceName() {
+    char uuid[37];
+    uuid_t uuid_bin;
+    uuid_generate(uuid_bin);
+    uuid_unparse(uuid_bin, uuid);
+
+    //TODO: for readability we might want to add username
+    //      but because we are operating on a fake user here
+    //      the actual user name is not available.
+    sds auto_ns = sdsempty();
+    return sdscatfmt(auto_ns, "::%s", uuid);
+}
+
 redisNamespace *getNamespace(const char* name) {
     sds ns_name = sdsnew(name);
     redisNamespace *ns = (redisNamespace *) dictFetchValue(g_pserver->namespaces, ns_name);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3501,7 +3501,7 @@ redisNamespace *getNamespace(const char* name) {
         ns->name = sdsnew(ns_name);
         ns->pubsub_channels = dictCreate(&keylistDictType,NULL);
         ns->pubsub_patterns = dictCreate(&keylistDictType,NULL);
-        ns->db = (redisDb**)zmalloc(sizeof(redisDb*)*std::min(cserver.dbnum,cserver.ns_dbnum), MALLOC_LOCAL);
+        ns->db = (redisDb**)zcalloc(sizeof(void *)*std::min(cserver.dbnum,cserver.ns_dbnum), MALLOC_LOCAL);
         dictAdd(g_pserver->namespaces, sdsnew(ns_name), ns);
     }
     sdsfree(ns_name);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1174,6 +1174,10 @@ struct redisCommand redisCommandTable[] = {
      {"allocate",allocateCommand,4,
       "ok-loading fast ok-stale @keyspace",
       0,NULL,0,0,0,0,0,0},
+
+    {"selectns",selectNsCommand,3,
+     "admin ok-loading fast ok-stale @keyspace",
+     0,NULL,0,0,0,0,0,0},
 };
 
 /*============================ Utility functions ============================ */

--- a/src/server.h
+++ b/src/server.h
@@ -1619,6 +1619,7 @@ struct redisServer {
     mode_t umask;               /* The umask value of the process on startup */
     std::atomic<int> hz;        /* serverCron() calls frequency in hertz */
     int in_fork_child;          /* indication that this is a fork child */
+    int last_allocated_db;      /* store last allocated db, to speed up allocation */
     redisDb *db;
     redisNamespace *default_namespace;
     ::dict *namespaces;

--- a/src/server.h
+++ b/src/server.h
@@ -1512,6 +1512,11 @@ struct redisServerThreadVars {
     std::vector<client*> vecclientsProcess;
 };
 
+struct redisMasterConnInfo {
+    char *ip;
+    int port;
+};
+
 struct redisMaster {
     char *masteruser;               /* AUTH with this user and masterauth with master */
     char *masterauth;               /* AUTH with this password with master */
@@ -1850,7 +1855,8 @@ struct redisServer {
     int repl_diskless_sync_delay;   /* Delay to start a diskless repl BGSAVE. */
     /* Replication (replica) */
     list *masters;
-    int enable_multimaster; 
+    list *repl_init_masters;        /* temp variable to hold the master ip/port pairs to init after config parsing */
+    int enable_multimaster;
     int repl_timeout;               /* Timeout after N seconds of master idle */
     int repl_syncio_timeout; /* Timeout for synchronous I/O calls */
     int repl_disable_tcp_nodelay;   /* Disable TCP_NODELAY after SYNC? */

--- a/src/server.h
+++ b/src/server.h
@@ -1299,7 +1299,7 @@ struct sharedObjectsStruct {
     *time, *pxat, *px, *retrycount, *force, *justid, 
     *lastid, *ping, *replping, *setid, *keepttl, *load, *createconsumer,
     *getack, *special_asterick, *special_equals, *default_username,
-    *hdel, *zrem, *mvccrestore, *pexpirememberat, *redacted,
+    *hdel, *zrem, *mvccrestore, *pexpirememberat, *redacted, *allocate,
     *select[PROTO_SHARED_SELECT_CMDS],
     *integers[OBJ_SHARED_INTEGERS],
     *mbulkhdr[OBJ_SHARED_BULKHDR_LEN], /* "*<value>\r\n" */
@@ -1564,7 +1564,7 @@ struct redisServerConst {
                         *zpopmaxCommand, *sremCommand, *execCommand,
                         *expireCommand, *pexpireCommand, *xclaimCommand,
                         *xgroupCommand, *rreplayCommand, *rpoplpushCommand,
-                        *hdelCommand, *zremCommand, *lmoveCommand;
+                        *hdelCommand, *zremCommand, *lmoveCommand, *allocateCommand;
 
     /* Configuration */
     char *default_masteruser;               /* AUTH with this user and masterauth with master */
@@ -2785,6 +2785,7 @@ void discardDbBackup(dbBackup *buckup, int flags, void(callback)(void*));
 
 
 int selectDb(client *c, int id);
+int selectDbNamespaced(client *c, int id);
 void signalModifiedKey(client *c, redisDb *db, robj *key);
 void signalFlushedDb(int dbid, int async);
 unsigned int getKeysInSlot(unsigned int hashslot, robj **keys, unsigned int count);
@@ -2939,6 +2940,7 @@ void incrbyCommand(client *c);
 void decrbyCommand(client *c);
 void incrbyfloatCommand(client *c);
 void selectCommand(client *c);
+void allocateCommand(client *c);
 void swapdbCommand(client *c);
 void randomkeyCommand(client *c);
 void keysCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -2949,6 +2949,7 @@ void incrbyCommand(client *c);
 void decrbyCommand(client *c);
 void incrbyfloatCommand(client *c);
 void selectCommand(client *c);
+void selectNsCommand(client *c);
 void allocateCommand(client *c);
 void swapdbCommand(client *c);
 void randomkeyCommand(client *c);

--- a/src/server.h
+++ b/src/server.h
@@ -997,6 +997,10 @@ struct redisDb {
     list *defrag_later;         /* List of key names to attempt to defrag one by one, gradually. */
 };
 
+struct redisNamespaceCommandStats {
+    long long microseconds, calls, rejected_calls, failed_calls;
+};
+
 struct redisNamespace {
     sds name;
     redisDb **db;
@@ -1008,6 +1012,9 @@ struct redisNamespace {
     ::dict *repl_scriptcache_dict;       /* SHA1 all slaves are aware of. */
     list *repl_scriptcache_fifo;         /* First in, first out LRU eviction. */
     unsigned int repl_scriptcache_size;  /* Max number of elements. */
+
+    redisNamespaceCommandStats *stat_commands;
+    long long stat_numcommands;
 };
 
 /* Declare database backup that include redis main DBs and slots to keys map.
@@ -2658,6 +2665,7 @@ void updateDictResizePolicy(void);
 int htNeedsResize(dict *dict);
 void populateCommandTable(void);
 void resetCommandTableStats(void);
+void resetCommandTableStatsNs(redisNamespace *ns);
 void resetErrorTableStats(void);
 void adjustOpenFilesLimit(void);
 void incrementErrorCount(const char *fullerr, size_t namelen);

--- a/src/server.h
+++ b/src/server.h
@@ -2783,7 +2783,7 @@ robj *dbUnshareStringValue(redisDb *db, robj *key, robj *o);
 #define EMPTYDB_ASYNC (1<<0)    /* Reclaim memory in another thread. */
 long long emptyDb(int dbnum, int flags, void(callback)(void*));
 long long emptyDbStructure(redisDb *dbarray, int dbnum, int async, void(callback)(void*));
-void flushAllDataAndResetRDB(int flags);
+void flushAllDataAndResetRDB(redisNamespace *ns, int flags);
 long long dbTotalServerKeyCount();
 dbBackup *backupDb(void);
 void restoreDbBackup(dbBackup *buckup);

--- a/src/server.h
+++ b/src/server.h
@@ -2792,6 +2792,7 @@ void discardDbBackup(dbBackup *buckup, int flags, void(callback)(void*));
 
 int selectDb(client *c, int id);
 int selectDbNamespaced(client *c, int id);
+void printDbMap();
 void signalModifiedKey(client *c, redisDb *db, robj *key);
 void signalFlushedDb(int dbid, int async);
 unsigned int getKeysInSlot(unsigned int hashslot, robj **keys, unsigned int count);

--- a/src/server.h
+++ b/src/server.h
@@ -1574,6 +1574,7 @@ struct redisServerConst {
     /* Configuration */
     char *default_masteruser;               /* AUTH with this user and masterauth with master */
     char *default_masterauth;               /* AUTH with this password with master */
+    char *default_user_namespace;           /* default user namespace */
     int verbosity;                  /* Loglevel in keydb.conf */
     int maxidletime;                /* Client timeout in seconds */
     int tcpkeepalive;               /* Set SO_KEEPALIVE if non-zero. */
@@ -2156,6 +2157,7 @@ extern dictType sdsReplyDictType;
 
 /* Namespaces */
 redisNamespace *getNamespace(const char* name);
+sds generateAutoNamespaceName();
 
 /* Modules */
 void moduleInitModulesSystem(void);

--- a/tests/assets/user-namespaces.acl
+++ b/tests/assets/user-namespaces.acl
@@ -1,0 +1,4 @@
+user alice on ~* +@all -@dangerous -@admin >alice ::ns1
+user bob on ~* +@all -@dangerous -@admin >bob ::ns2
+user b2 on ~* +@all -@dangerous -@admin >b2 ::ns2
+user default on nopass ~* +@all ::

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -161,6 +161,7 @@ start_server {tags {"introspection"}} {
             active-replica
             bind
             set-proc-title
+            acl-namespace-default
         }
 
         if {!$::tls} {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -147,6 +147,7 @@ start_server {tags {"introspection"}} {
             supervised
             syslog-facility
             databases
+            databases-per-namespace
             io-threads
             logfile
             unixsocketperm

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -1,7 +1,7 @@
 start_server {tags {"introspection"}} {
     test {CLIENT LIST} {
         r client list
-    } {*addr=*:* fd=* age=* idle=* flags=N db=9 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client*}
+    } {*addr=*:* fd=* age=* idle=* flags=N db=9* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client* ns=*}
 
     test {CLIENT LIST with IDs} {
         set myid [r client id]
@@ -11,7 +11,7 @@ start_server {tags {"introspection"}} {
 
     test {CLIENT INFO} {
         r client info
-    } {*addr=*:* fd=* age=* idle=* flags=N db=9 sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client*}
+    } {*addr=*:* fd=* age=* idle=* flags=N db=9* sub=0 psub=0 multi=-1 qbuf=26 qbuf-free=* argv-mem=* obl=0 oll=0 omem=0 tot-mem=* events=r cmd=client* ns=*}
 
     test {MONITOR can log executed commands} {
         set rd [redis_deferring_client]

--- a/tests/unit/namespace.tcl
+++ b/tests/unit/namespace.tcl
@@ -1,0 +1,64 @@
+set server_path [tmpdir "server.namepsace"]
+exec cp -f tests/assets/user-namespaces.acl $server_path
+start_server [list overrides [list "dir" $server_path "aclfile" "user-namespaces.acl"]] {
+    # user alice on ~* +@all -@dangerous -@admin >alice ::ns1
+    # user bob on ~* +@all -@dangerous -@admin >bob ::ns2
+    # user b2 on ~* +@all -@dangerous -@admin >b2 ::ns2
+    # user default on nopass ~* +@all ::
+
+    test {alice can set keys in multiple databases} {
+        r AUTH alice alice
+        r SELECT 0
+        r SET name alice0
+        r SELECT 1
+        r SET name alice1
+        r SELECT 2
+        r SET name alice2
+    }
+
+    test {bob does not have acces to the latest db of alice} {
+        r AUTH bob bob
+        assert_equal "" [r GET name]
+    }
+
+    test {bob can set keys in multiple databases} {
+        r AUTH bob bob
+        r SELECT 0
+        r SET name bob0
+        r SELECT 1
+        r SET name bob1
+        r SELECT 2
+        r SET name bob2
+    }
+
+    test {alice's keys are not overwritten by bob} {
+        r AUTH alice alice
+        r SELECT 0
+        assert_equal "alice0" [r GET name]
+        r SELECT 1
+        assert_equal "alice1" [r GET name]
+        r SELECT 2
+        assert_equal "alice2" [r GET name]
+    }
+
+   test {bob's keys are not overwritten by alice} {
+        r AUTH bob bob
+        r SELECT 0
+        assert_equal "bob0" [r GET name]
+        r SELECT 1
+        assert_equal "bob1" [r GET name]
+        r SELECT 2
+        assert_equal "bob2" [r GET name]
+    }
+
+    test {b2 can see bob's keys are not overwritten by alice} {
+        r AUTH b2 b2
+        r SELECT 0
+        assert_equal "bob0" [r GET name]
+        r SELECT 1
+        assert_equal "bob1" [r GET name]
+        r SELECT 2
+        assert_equal "bob2" [r GET name]
+    }
+}
+

--- a/tests/unit/namespace.tcl
+++ b/tests/unit/namespace.tcl
@@ -82,5 +82,20 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user-namespaces
         r SELECTNS 1 ::ns2
         assert_equal "bob1" [r GET name]
     }
+
+    test {Scripts commands should not affect other namespaces} {
+        r AUTH alice alice
+        set sha [r SCRIPT LOAD "return true"]
+        assert_equal "1" [r SCRIPT EXISTS $sha]
+        r AUTH bob bob
+        assert_equal "0" [r SCRIPT EXISTS $sha]
+        set sha2 [r SCRIPT LOAD "return true"]
+        assert_equal $sha $sha2
+        r SCRIPT FLUSH
+        assert_equal "0" [r SCRIPT EXISTS $sha]
+        r AUTH alice alice
+        assert_equal "1" [r SCRIPT EXISTS $sha]
+        r EVALSHA $sha 0
+    }
 }
 

--- a/tests/unit/namespace.tcl
+++ b/tests/unit/namespace.tcl
@@ -71,6 +71,16 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user-namespaces
         assert_equal "bob2" [r GET name]
     }
 
-
+    test {admin can select databases in different namespaces} {
+        r AUTH default ""
+        r SELECTNS 0 ::ns1
+        assert_equal "alice0" [r GET name]
+        r SELECTNS 1 ::ns1
+        assert_equal "alice1" [r GET name]
+        r SELECTNS 0 ::ns2
+        assert_equal "bob0" [r GET name]
+        r SELECTNS 1 ::ns2
+        assert_equal "bob1" [r GET name]
+    }
 }
 

--- a/tests/unit/namespace.tcl
+++ b/tests/unit/namespace.tcl
@@ -6,6 +6,16 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user-namespaces
     # user b2 on ~* +@all -@dangerous -@admin >b2 ::ns2
     # user default on nopass ~* +@all ::
 
+    test {::auto generates unique namespace} {
+        r ACL setuser auto1 on ~* +@all -@dangerous -@admin >auto ::auto
+        set ns1 [dict get [r ACL getuser auto1] namespace]
+        assert_match "::*-*-*-*" $ns1
+        r ACL setuser auto2 on ~* +@all -@dangerous -@admin >auto ::auto
+        set ns2 [dict get [r ACL getuser auto2] namespace]
+        assert_match "::*-*-*-*" $ns2
+        assert {$ns1 != $ns2}
+    }
+
     test {alice can set keys in multiple databases} {
         r AUTH alice alice
         r SELECT 0
@@ -51,7 +61,7 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user-namespaces
         assert_equal "bob2" [r GET name]
     }
 
-    test {b2 can see bob's keys are not overwritten by alice} {
+    test {b2 can see bob's keys} {
         r AUTH b2 b2
         r SELECT 0
         assert_equal "bob0" [r GET name]
@@ -60,5 +70,7 @@ start_server [list overrides [list "dir" $server_path "aclfile" "user-namespaces
         r SELECT 2
         assert_equal "bob2" [r GET name]
     }
+
+
 }
 

--- a/tests/unit/rreplay.tcl
+++ b/tests/unit/rreplay.tcl
@@ -2,6 +2,7 @@ start_server {tags {"rreplay"} overrides {active-replica yes}} {
 
     test {RREPLAY use current db} {
         r debug force-master yes
+        r allocate :: 4 0
         r select 4
         r set dbnum invalid
         r rreplay "f4d5b2b5-4f07-4ee5-a4f2-5dc98507dfce" "*3\r\n\$3\r\nSET\r\n\$5\r\ndbnum\r\n\$4\r\nfour\r\n"
@@ -11,6 +12,7 @@ start_server {tags {"rreplay"} overrides {active-replica yes}} {
 
     test {RREPLAY db different} {
         r debug force-master yes
+        r allocate :: 2 2
         r select 4
         r set testkey four
         r rreplay "f4d5b2b5-4f07-4ee5-a4f2-5dc98507dfce" "*3\r\n\$3\r\nSET\r\n\$7\r\ntestkey\r\n\$4\r\nbebe\r\n" 2


### PR DESCRIPTION
This is an proof of concept implementation for namespaces to provide multi-tenancy support (see issue #286 / https://community.keydb.dev/t/multi-tenancy-support/78 ) 

### Background:

We are currently running separate redis instances for each website/application we host on our kubernetes clusters (>100 sites). Most of these sites are have a fairly low volume of traffic.
This is sub-optimal for several reasons:
- extra number of pods
- memory usage
- currently no HA setup for all websites as this would increase the number of pods + memory significantly

I did a [POC](https://github.com/thisisdevelopment/redis-mt) where I implemented the functionality in a proxy; this was based on key prefixes. but it is quite hard to make that transparent to the applications.

So I started looking into implementing this functionality in KeyDB itself; without relying on key prefixes. This would mean a different set of databases for each user. As far as I (google) could tell redis seems to scale pretty good up to 1000 databases .. as most applications only need 1 or 2 redis databases, this would mean supporting at least 100 users seems attainable.

*note*: Please be gentle; this is one of my first things I have done in C/C++ in a very long time.

### Implementation:

The idea is simple; each user has an associated namespace. Users still see databases 0 .. <max db's>, however that are virtual databases; each namespace would have a different mapping to the global databases.
Allocations of those databases are done dynamically so we only need to maintain the databases that are used.

Besides databases also channels are namespaced. Instead of a global list of pubsub channels / patterns this is now maintained per namespace.

Most internal redis functionality does not need to know about namespaces. `client->db` still points to the current redis db. It is just that `SELECT 0` will now select the virtual db 0, which can be mapped to the global database with id `10` for example.

### TODO:
- [x] improve performance of allocation
- [x] support `::auto` for as special namespace to automatically create a new unique namespace for a user
- [x] support switching of namespaces for users with admin privileges
- [x] move script cache to namespace 
- [x] stats/info per namespace
- [ ] add more tests
- [ ] add documentation
- [ ] remove some debugging asserts
- [ ] automatically remove mapping when a database is empty an not in use by any clients anymore
- [ ] fix race conditions in multi-master when allocating databases
- [ ] add per namespace memory limit
