### PR TITLE
Remove nullptr subtraction in pqsort.c

### DIFF
--- a/src/pqsort.c
+++ b/src/pqsort.c
@@ -41,6 +41,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 static inline char	*med3 (char *, char *, char *,
     int (*)(const void *, const void *));

--- a/src/pqsort.c
+++ b/src/pqsort.c
@@ -62,7 +62,7 @@ static inline void	 swapfunc (char *, char *, size_t, int);
         } while (--i > 0);				\
 }
 
-#define SWAPINIT(a, es) swaptype = ((char *)a - (char *)0) % sizeof(long) || \
+#define SWAPINIT(a, es) swaptype = (char *)a % sizeof(long) || \
 	es % sizeof(long) ? 2 : es == sizeof(long)? 0 : 1;
 
 static inline void

--- a/src/pqsort.c
+++ b/src/pqsort.c
@@ -62,7 +62,7 @@ static inline void	 swapfunc (char *, char *, size_t, int);
         } while (--i > 0);				\
 }
 
-#define SWAPINIT(a, es) swaptype = (char *)a % sizeof(long) || \
+#define SWAPINIT(a, es) swaptype = (uintptr_t)a % sizeof(long) || \
 	es % sizeof(long) ? 2 : es == sizeof(long)? 0 : 1;
 
 static inline void


### PR DESCRIPTION
nullptr subtraction behavior is undefined
MacOS warning: 
pqsort.c:106:7: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
loop:   SWAPINIT(a, es);
        ^~~~~~~~~~~~~~~
pqsort.c:65:47: note: expanded from macro 'SWAPINIT'
#define SWAPINIT(a, es) swaptype = ((char *)a - (char *)0) % sizeof(long) || \